### PR TITLE
check: Check Domains, allow RDNS only for nets this community has

### DIFF
--- a/check
+++ b/check
@@ -67,6 +67,7 @@ def check_net(family, net, nets, community):
 
     return errcnt
 
+
 def check_rdns(data):
     errcnt = 0
 
@@ -78,42 +79,41 @@ def check_rdns(data):
             for net_str in data['networks']['IPv6'.lower()]:
                 try:
                     net = ip_family_network('IPv6', net_str)
-                    net_length = math.floor(net.prefixlen / 4) #4 bits per character
+                    net_length = math.floor(net.prefixlen / 4)  # 4 bits per character
                     # by rounding down instead of correcly handling partially used characters
                     # we generate false-passes but no false-warnings for prefixlength % 4 != 0
 
                     net_dns = net \
                         .network_address \
                         .exploded \
-                        .replace(":", "") \
-                        [:net_length]
+                        .replace(":", "")[:net_length]
+
                     net_dns = '.'.join(reversed(net_dns))
                     net_dns = net_dns + '.ip6.arpa'
 
                     allowed_domains.append(net_dns)
                 except ValueError:
-                    errcnt = errcnt + 0 #dummy statement to supress error about empty except-block
+                    errcnt = errcnt + 0  # dummy statement to supress error about empty except-block
 
         if 'IPv4'.lower() in data['networks']:
             for net_str in data['networks']['IPv4'.lower()]:
                 try:
                     net = ip_family_network('IPv4', net_str)
-                    net_length = math.floor(net.prefixlen / 8) #8 bits per block
+                    net_length = math.floor(net.prefixlen / 8)  # 8 bits per block
                     # by rounding down instead of correcly handling partially used blocks
                     # we generate false-passes but no false-warnings for prefixlength % 8 != 0
 
                     net_dns = net \
                         .network_address \
                         .exploded \
-                        .split(".") \
-                        [:net_length]
+                        .split(".")[:net_length]
 
                     net_dns = '.'.join(reversed(net_dns))
                     net_dns = net_dns + '.in-addr.arpa'
 
                     allowed_domains.append(net_dns)
                 except ValueError:
-                    errcnt = errcnt + 0 #dummy statement to supress error about empty except-block
+                    errcnt = errcnt + 0  # dummy statement to supress error about empty except-block
 
     if 'domains' in data:
         for domain in data['domains']:
@@ -128,6 +128,7 @@ def check_rdns(data):
                     error("Illegal RDNS-Domain: found no matching net for %s (found nets: %s)" % (domain, allowed_domains))
 
     return errcnt
+
 
 def do_checks(srcdir):
     """

--- a/check
+++ b/check
@@ -96,7 +96,6 @@ def check_rdns(data):
 
                 allowed_domains.append(net_rdns)
 
-
         if 'ipv4' in data['networks']:
             for net_str in data['networks']['ipv4']:
                 try:

--- a/check
+++ b/check
@@ -75,55 +75,55 @@ def check_rdns(data):
 
     # find allowed rdns-domain-names
     if 'networks' in data:
-        if 'IPv6'.lower() in data['networks']:
-            for net_str in data['networks']['IPv6'.lower()]:
+        if 'ipv6' in data['networks']:
+            for net_str in data['networks']['ipv6']:
                 try:
                     net = ip_family_network('IPv6', net_str)
                     net_length = math.floor(net.prefixlen / 4)  # 4 bits per character
                     # by rounding down instead of correcly handling partially used characters
                     # we generate false-passes but no false-warnings for prefixlength % 4 != 0
 
-                    net_dns = net \
+                    net_prefix = net \
                         .network_address \
                         .exploded \
                         .replace(":", "")[:net_length]
 
-                    net_dns = '.'.join(reversed(net_dns))
-                    net_dns = net_dns + '.ip6.arpa'
+                    net_rdns = '.'.join(reversed(net_prefix))
+                    net_rdns = '{}.ip6.arpa'.format(net_rdns)
 
-                    allowed_domains.append(net_dns)
+                    allowed_domains.append(net_rdns)
                 except ValueError:
-                    errcnt = errcnt + 0  # dummy statement to supress error about empty except-block
+                    pass
 
-        if 'IPv4'.lower() in data['networks']:
-            for net_str in data['networks']['IPv4'.lower()]:
+        if 'ipv4' in data['networks']:
+            for net_str in data['networks']['ipv4']:
                 try:
                     net = ip_family_network('IPv4', net_str)
                     net_length = math.floor(net.prefixlen / 8)  # 8 bits per block
                     # by rounding down instead of correcly handling partially used blocks
                     # we generate false-passes but no false-warnings for prefixlength % 8 != 0
 
-                    net_dns = net \
+                    net_prefix = net \
                         .network_address \
                         .exploded \
                         .split(".")[:net_length]
 
-                    net_dns = '.'.join(reversed(net_dns))
-                    net_dns = net_dns + '.in-addr.arpa'
+                    net_rdns = '.'.join(reversed(net_prefix))
+                    net_rdns = '{}.in-addr.arpa'.format(net_rdns)
 
-                    allowed_domains.append(net_dns)
+                    allowed_domains.append(net_rdns)
                 except ValueError:
-                    errcnt = errcnt + 0  # dummy statement to supress error about empty except-block
+                    pass
 
     if 'domains' in data:
         for domain in data['domains']:
             if domain.endswith('.ip6.arpa') or domain.endswith('.in-addr.arpa'):
-                failed = True
-                for net_dns in allowed_domains:
-                    if domain.endswith(net_dns):
-                        failed = False
+                found = False
+                for reverse_domain in allowed_domains:
+                    if domain.endswith(reverse_domain):  # we want communitys to be able to announce only a part of the net as RDNS-capable
+                        found = True
 
-                if failed:
+                if not found:
                     errcnt += 1
                     error("Illegal RDNS-Domain: found no matching net for %s (found nets: %s)" % (domain, allowed_domains))
 

--- a/check
+++ b/check
@@ -2,6 +2,7 @@
 
 import sys
 import ipaddress
+import math
 from optparse import OptionParser
 from math import floor
 from filereader import get_communities_data
@@ -66,6 +67,67 @@ def check_net(family, net, nets, community):
 
     return errcnt
 
+def check_rdns(data):
+    errcnt = 0
+
+    allowed_domains = []
+
+    # find allowed rdns-domain-names
+    if 'networks' in data:
+        if 'IPv6'.lower() in data['networks']:
+            for net_str in data['networks']['IPv6'.lower()]:
+                try:
+                    net = ip_family_network('IPv6', net_str)
+                    net_length = math.floor(net.prefixlen / 4) #4 bits per character
+                    # by rounding down instead of correcly handling partially used characters
+                    # we generate false-passes but no false-warnings for prefixlength % 4 != 0
+
+                    net_dns = net \
+                        .network_address \
+                        .exploded \
+                        .replace(":", "") \
+                        [:net_length]
+                    net_dns = '.'.join(reversed(net_dns))
+                    net_dns = net_dns + '.ip6.arpa'
+
+                    allowed_domains.append(net_dns)
+                except ValueError:
+                    errcnt = errcnt + 0 #dummy statement to supress error about empty except-block
+
+        if 'IPv4'.lower() in data['networks']:
+            for net_str in data['networks']['IPv4'.lower()]:
+                try:
+                    net = ip_family_network('IPv4', net_str)
+                    net_length = math.floor(net.prefixlen / 8) #8 bits per block
+                    # by rounding down instead of correcly handling partially used blocks
+                    # we generate false-passes but no false-warnings for prefixlength % 8 != 0
+
+                    net_dns = net \
+                        .network_address \
+                        .exploded \
+                        .split(".") \
+                        [:net_length]
+
+                    net_dns = '.'.join(reversed(net_dns))
+                    net_dns = net_dns + '.in-addr.arpa'
+
+                    allowed_domains.append(net_dns)
+                except ValueError:
+                    errcnt = errcnt + 0 #dummy statement to supress error about empty except-block
+
+    if 'domains' in data:
+        for domain in data['domains']:
+            if domain.endswith('.ip6.arpa') or domain.endswith('.in-addr.arpa'):
+                failed = True
+                for net_dns in allowed_domains:
+                    if domain.endswith(net_dns):
+                        failed = False
+
+                if failed:
+                    errcnt += 1
+                    error("Illegal RDNS-Domain: found no matching net for %s (found nets: %s)" % (domain, allowed_domains))
+
+    return errcnt
 
 def do_checks(srcdir):
     """
@@ -145,6 +207,9 @@ def do_checks(srcdir):
                                             net,
                                             networks[family],
                                             community)
+
+        if 'domains' in data:
+            errcnt += check_rdns(data)
 
     print(ANSI_COLOR_WARN, "%d warning(s)" % warncnt, ANSI_COLOR_RESET)
     print(ANSI_COLOR_ERR, "%d error(s)" % errcnt, ANSI_COLOR_RESET)

--- a/check
+++ b/check
@@ -79,41 +79,44 @@ def check_rdns(data):
             for net_str in data['networks']['ipv6']:
                 try:
                     net = ip_family_network('IPv6', net_str)
-                    net_length = math.floor(net.prefixlen / 4)  # 4 bits per character
-                    # by rounding down instead of correcly handling partially used characters
-                    # we generate false-passes but no false-warnings for prefixlength % 4 != 0
-
-                    net_prefix = net \
-                        .network_address \
-                        .exploded \
-                        .replace(":", "")[:net_length]
-
-                    net_rdns = '.'.join(reversed(net_prefix))
-                    net_rdns = '{}.ip6.arpa'.format(net_rdns)
-
-                    allowed_domains.append(net_rdns)
                 except ValueError:
-                    pass
+                    continue
+
+                net_length = math.floor(net.prefixlen / 4)  # 4 bits per character
+                # by rounding down instead of correcly handling partially used characters
+                # we generate false-passes but no false-warnings for prefixlength % 4 != 0
+
+                net_prefix = net \
+                    .network_address \
+                    .exploded \
+                    .replace(":", "")[:net_length]
+
+                net_rdns = '.'.join(reversed(net_prefix))
+                net_rdns = '{}.ip6.arpa'.format(net_rdns)
+
+                allowed_domains.append(net_rdns)
+
 
         if 'ipv4' in data['networks']:
             for net_str in data['networks']['ipv4']:
                 try:
                     net = ip_family_network('IPv4', net_str)
-                    net_length = math.floor(net.prefixlen / 8)  # 8 bits per block
-                    # by rounding down instead of correcly handling partially used blocks
-                    # we generate false-passes but no false-warnings for prefixlength % 8 != 0
-
-                    net_prefix = net \
-                        .network_address \
-                        .exploded \
-                        .split(".")[:net_length]
-
-                    net_rdns = '.'.join(reversed(net_prefix))
-                    net_rdns = '{}.in-addr.arpa'.format(net_rdns)
-
-                    allowed_domains.append(net_rdns)
                 except ValueError:
-                    pass
+                    continue
+
+                net_length = math.floor(net.prefixlen / 8)  # 8 bits per block
+                # by rounding down instead of correcly handling partially used blocks
+                # we generate false-passes but no false-warnings for prefixlength % 8 != 0
+
+                net_prefix = net \
+                    .network_address \
+                    .exploded \
+                    .split(".")[:net_length]
+
+                net_rdns = '.'.join(reversed(net_prefix))
+                net_rdns = '{}.in-addr.arpa'.format(net_rdns)
+
+                allowed_domains.append(net_rdns)
 
     if 'domains' in data:
         for domain in data['domains']:


### PR DESCRIPTION
I did this because I did this mistake at least once. This script found the following mistakes:

    Checking darmstadt
     Illegal RDNS-Domain: found no matching net for a.d.f.f.e.e.f.f.a.c.d.f.ip6.arpa (found nets: ['0.0.0.0.a.d.f.f.e.e.f.f.a.c.d.f.ip6.arpa', '223.10.in-addr.arpa'])

    Checking goettingen
     Illegal RDNS-Domain: found no matching net for 5.8.9.c.c.f.6.3.6.e.d.f.ip6.arpa (found nets: ['0.0.0.0.5.8.9.c.c.f.6.3.6.e.d.f.ip6.arpa', '109.10.in-addr.arpa'])

    Checking muenster
     Illegal RDNS-Domain: found no matching net for 3.5.a.a.e.2.e.8.6.d.f.ip6.arpa (found nets: ['3.5.a.0.a.e.2.e.8.6.d.f.ip6.arpa', '43.10.in-addr.arpa'])

    Checking trier
     Illegal RDNS-Domain: found no matching net for f.0.c.f.e.e.f.f.a.c.d.f.ip6.arpa (found nets: ['0.0.0.0.f.0.c.f.e.e.f.f.a.c.d.f.ip6.arpa', '0.c.f.7.f.b.0.1.0.0.2.ip6.arpa', '172.10.in-addr.arpa'])

