### PR TITLE
Allow meta-* to override ICVPN_NETWORKS check

### DIFF
--- a/check
+++ b/check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import ipaddress
@@ -58,9 +58,10 @@ def check_net(family, net, nets, community):
     else:
         for other in nets:
             if other.overlaps(net):
-                errcnt += 1
-                error("%s Network overlap: %s (%s), %s (%s)" %
-                      (family, community, net, nets[other], other))
+                if 'meta-' not in community:
+                    errcnt += 1
+                    error("%s Network overlap: %s (%s), %s (%s)" %
+                          (family, community, net, nets[other], other))
 
         if errcnt == 0:
             nets[net] = community


### PR DESCRIPTION
To allow meta-icvpn to pass the (Travis) check, meta-* needs to be whitelisted. This is a kludge as ICVPN_NETWORKS is just the preset for that dict; in fact, I'd maybe make the "community" names explicit instead of whitelisting "meta-*", but then python is really not my language of choice.

It's a POC, opening a gap in case more people create "meta-xyz" files; then again, to define DNS for the reverse zones for ICVPN IP ranges in icvpn-meta, something needs to be done. Feel free to reject AND provide a better solution, just don't count on me to extend the python3 script to your wishes; python hates me and I hate python.