### PR TITLE
Make /20 the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ optional arguments:
                         path to the local copy of the icvpn-metarepository
                         (Default: ../icvpn-meta/)
   -p PREFIX, --prefix-length PREFIX
-                        Required prefix length (Default: 16)
+                        Required prefix length (Default: 20)
   -c COUNT, --count COUNT
                         The amount of options to show (Default: 5)
 

--- a/findfree
+++ b/findfree
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                         help="path to the local copy of the icvpn-meta"
                              "repository (Default: ../icvpn-meta/)")
     PARSER.add_argument('-p', '--prefix-length',
-                        type=int, default=16,
+                        type=int, default=20,
                         metavar='PREFIX', dest='required_prefix_len',
                         help="Required prefix length (Default: 16)")
     PARSER.add_argument('-c', '--count',


### PR DESCRIPTION
Because we want /20 by default to stop people from (accidently) allocating to big nets