### PR TITLE
deb python-yaml only contains modules for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ working directory. However, they all support the `-s` or `--source` switch to
 specify another location.
 
 ### Debian
-On Debian `apt-get install python-yaml python3-yaml` should install all dependencies.
+On Debian `apt-get install python3-yaml python3-requests python3-prettytable
+python3-jinja2` should install all dependencies.
 
 #### Debian Wheezy (oldstable)
 You might run into problems because of a missing ipaddress module (shipped with python >= 3.3), so install it via pip.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ working directory. However, they all support the `-s` or `--source` switch to
 specify another location.
 
 ### Debian
-On Debian `apt-get install python-yaml` should install all dependencies.
+On Debian `apt-get install python-yaml python3-yaml` should install all dependencies.
 
 #### Debian Wheezy (oldstable)
 You might run into problems because of a missing ipaddress module (shipped with python >= 3.3), so install it via pip.

--- a/check
+++ b/check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import ipaddress

--- a/mkbgp
+++ b/mkbgp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import socket
 from collections import defaultdict

--- a/mkdns
+++ b/mkdns
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from textwrap import dedent
 from optparse import OptionParser

--- a/mkroa
+++ b/mkroa
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from textwrap import dedent
 from argparse import ArgumentParser

--- a/mksmokeping
+++ b/mksmokeping
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from textwrap import dedent
 from argparse import ArgumentParser

--- a/mktable
+++ b/mktable
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 from ipaddress import ip_address, ip_network, IPv6Address

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests>=2.4.3
+PyYAML>=3.11
+argparse>=1.2.1
+prettytable>=0.7.2
+Jinja2>=2.7.3


### PR DESCRIPTION
findfree is needs python3, so python3-yaml has to be installed on
Debian to use it