### PR TITLE
mkbgp: Optionally set unreachable peers as passive

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ Options:
                         Exclude the comma-separated list of COMMUNITIES
   -p PREFIX, --prefix=PREFIX
                         Prefix, e.g. bgp_icvpn_
+  -P TIMEOUT, --passive-offline=TIMEOUT
+                        Add peers that take longer than TIMEOUT to
+                        respond at time of creation as passive peers
   -d TEMPLATE, --default=TEMPLATE
                         Default template/peer-group to use
   -t COMMUNITY:TEMPLATE, --template=COMMUNITY:TEMPLATE
                         Use different template/peer-group for some communities
-
 ```
 
 

--- a/mkbgp
+++ b/mkbgp
@@ -1,21 +1,24 @@
 #!/usr/bin/env python
 
+import socket
 from collections import defaultdict
 from textwrap import dedent
 from optparse import OptionParser
-from socket import AF_INET, AF_INET6, inet_pton
 from formatter import Formatter
 from filereader import get_communities_data
+from struct import unpack
 
 
 class BirdFormatter(Formatter):
     "Formatter for bind9 using type forward"
-    def add_data(self, asn, name, template, peer):
+    def add_data(self, asn, name, template, peer, passive=False):
         self.config.append(dedent("""
             protocol bgp {name} from {template} {{
-                neighbor {peer} as {asn};
-            }}
-            """.format(peer=peer, asn=asn, name=name, template=template)))
+                neighbor {peer} as {asn};""".format(
+            peer=peer, asn=asn, name=name, template=template)))
+        if passive:
+            self.config.append("    passive yes;")
+        self.config.append("}\n")
 
 
 class QuaggaFormatter(Formatter):
@@ -24,7 +27,7 @@ class QuaggaFormatter(Formatter):
     def add_comment(self, comment):
         self.config.append("! " + "\n! ".join(comment.split("\n")))
 
-    def add_data(self, asn, name, template, peer):
+    def add_data(self, asn, name, template, peer, passive=False):
         self.config.append(dedent("""
             neighbor {peer} remote-as {asn}
             neighbor {peer} description {name}
@@ -32,8 +35,25 @@ class QuaggaFormatter(Formatter):
         """.format(peer=peer, asn=asn, name=name, template=template)))
 
 
+def is_reachable(host, port, timeout):
+    """
+    Test reachability of host by opening a TCP connection to the specified
+    port.
+    """
+    try:
+        fd = socket.create_connection((host, port), timeout)
+        return True
+    except (socket.timeout, socket.error):
+        return False
+    finally:
+        try:
+            fd.close()
+        except:
+            pass
+
+
 def create_config(srcdir, exclude, prefix, defaulttemplate, templates, family,
-                  fmtclass):
+                  fmtclass, timeout):
     """
     Generates a configuration using all files in srcdir
     (non-recursively) excluding communities from 'exclude'.
@@ -59,8 +79,14 @@ def create_config(srcdir, exclude, prefix, defaulttemplate, templates, family,
 
             peer = d[family]
 
+            if timeout > 0:
+                passive = not is_reachable(peer, 179, timeout)
+            else:
+                passive = False
+
             formatter.add_data(asn, prefix + host,
-                               template[community], peer)
+                               template[community], peer,
+                               passive)
 
     print(formatter.finalize())
 
@@ -95,6 +121,10 @@ if __name__ == "__main__":
                       help="Prefix, e.g. bgp_icvpn_",
                       metavar="PREFIX",
                       default="")
+    parser.add_option("-P", "--passive-offline", dest="passive_offline",
+                      help="""Add peers that take longer than TIMEOUT to
+                              respond at time of creation as passive peers""",
+                      default=0, type="float", metavar="TIMEOUT",)
     parser.add_option("-d", "--default", dest="defaulttemplate",
                       help="Default template/peer-group to use",
                       metavar="TEMPLATE",
@@ -110,4 +140,5 @@ if __name__ == "__main__":
 
     create_config(options.src, set(options.exclude), options.prefix,
                   options.defaulttemplate, options.templates,
-                  options.family, formatters[options.fmt])
+                  options.family, formatters[options.fmt],
+                  options.passive_offline)

--- a/mkbgp
+++ b/mkbgp
@@ -7,6 +7,7 @@ from optparse import OptionParser
 from formatter import Formatter
 from filereader import get_communities_data
 from struct import unpack
+from multiprocessing.dummy import Pool
 
 
 class BirdFormatter(Formatter):
@@ -64,6 +65,7 @@ def create_config(srcdir, exclude, prefix, defaulttemplate, templates, family,
     formatter = fmtclass()
     template = defaultdict(lambda: defaulttemplate)
     template.update(dict(map(lambda s: s.split(":"), templates)))
+    peers = []
 
     for community, data in get_communities_data(srcdir, exclude):
         try:
@@ -79,14 +81,29 @@ def create_config(srcdir, exclude, prefix, defaulttemplate, templates, family,
 
             peer = d[family]
 
-            if timeout > 0:
-                passive = not is_reachable(peer, 179, timeout)
-            else:
-                passive = False
+            peers.append({
+                "asn": asn,
+                "host": host,
+                "community": community,
+                "peer": peer,
+                "passive": False,
+            })
 
-            formatter.add_data(asn, prefix + host,
-                               template[community], peer,
-                               passive)
+    if timeout > 0:
+        def update_peer_passive(peer):
+            peer["passive"] = not is_reachable(peer["peer"], 179, timeout)
+
+        Pool(len(peers)).map(update_peer_passive, peers)
+
+        # if all peers are passive, ignore the check results
+        if all(peer["passive"] for peer in peers):
+            for peer in peers:
+                peer["passive"] = False
+
+    for peer in peers:
+        formatter.add_data(peer["asn"], prefix + peer["host"],
+                           template[peer["community"]], peer["peer"],
+                           peer["passive"])
 
     print(formatter.finalize())
 

--- a/mkbgp
+++ b/mkbgp
@@ -12,10 +12,10 @@ class BirdFormatter(Formatter):
     "Formatter for bind9 using type forward"
     def add_data(self, asn, name, template, peer):
         self.config.append(dedent("""
-            protocol bgp %s from %s {
-                neighbor %s as %s;
-            }
-            """ % (name, template, peer, asn)))
+            protocol bgp {name} from {template} {{
+                neighbor {peer} as {asn};
+            }}
+            """.format(peer=peer, asn=asn, name=name, template=template)))
 
 
 class QuaggaFormatter(Formatter):
@@ -26,10 +26,10 @@ class QuaggaFormatter(Formatter):
 
     def add_data(self, asn, name, template, peer):
         self.config.append(dedent("""
-            neighbor %(peer)s remote-as %(asn)s
-            neighbor %(peer)s description %(name)s
-            neighbor %(peer)s peer-group %(template)s
-        """ % {"peer": peer, "asn": asn, "name": name, "template": template}))
+            neighbor {peer} remote-as {asn}
+            neighbor {peer} description {name}
+            neighbor {peer} peer-group {template}
+        """.format(peer=peer, asn=asn, name=name, template=template)))
 
 
 def create_config(srcdir, exclude, prefix, defaulttemplate, templates, family,
@@ -74,8 +74,8 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-f", "--format", dest="fmt",
                       help="""Create config in format FMT.
-                              Possible values: %s. Default: bird""" %
-                           ", ".join(formatters.keys()),
+                              Possible values: {}. Default: bird""".format(
+                          ", ".join(formatters.keys())),
                       metavar="FMT",
                       choices=list(formatters.keys()),
                       default="bird")


### PR DESCRIPTION
By passing -P <timeout>, the script now checks if the BGP peer is reachable by opening a TCP connection to the BGP port. If it isn't, it is added to the config nonetheless but only as passive peer, meaning that incoming connections from this peer will be accepted but no attempts to establish a connection is made.

NOTE: Only bird supports the passive peer feature, so only bird is supported by this new option. While supplying -P together with "-f quagga" isn't an error and will still do the checking, it doesn't change the resulting config in any way.