### PR TITLE
use natsort to sort smokeping entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ specify another location.
 
 ### Debian
 On Debian `apt-get install python3-yaml python3-requests python3-prettytable
-python3-jinja2` should install all dependencies.
+python3-jinja2 python3-natsort` should install all dependencies.
 
 #### Debian Wheezy (oldstable)
-You might run into problems because of a missing ipaddress module (shipped with python >= 3.3), so install it via pip.
+You might run into problems because of a missing ipaddress and natsort module (shipped with python >= 3.3), so install it via pip.
 ```
 apt-get install python3-yaml python3-pip
-pip-3.2 install ipaddress
+pip-3.2 install ipaddress natsort
 ```
 
 

--- a/mksmokeping
+++ b/mksmokeping
@@ -4,10 +4,10 @@ from textwrap import dedent
 from argparse import ArgumentParser
 
 try:
-  from natsort import natsorted as sorted
+    from natsort import natsorted as sorted
 except ImportError:
-  #use the list.sorted() function
-  pass 
+    # use the list.sorted() function
+    pass
 
 from formatter import Formatter
 from filereader import get_communities_data

--- a/mksmokeping
+++ b/mksmokeping
@@ -3,6 +3,12 @@
 from textwrap import dedent
 from argparse import ArgumentParser
 
+try:
+  from natsort import natsorted as sorted
+except ImportError:
+  #use the list.sorted() function
+  pass 
+
 from formatter import Formatter
 from filereader import get_communities_data
 


### PR DESCRIPTION
use [natsort](https://pypi.python.org/pypi/natsort) to sort smokeping entries

Vorhher:
```
+ nord
menu = nord
title = nord



++ ipv4-nordgw0
menu = ipv4-nordgw0
title = ipv4-nordgw0
probe = FPing
host = 10.207.11.10
#alerts = someloss



++ ipv6-nordgw0
menu = ipv6-nordgw0
title = ipv6-nordgw0
probe = FPing6
host = fec0::a:cf:b:a
#alerts = someloss



++ ipv4-nordgw1
menu = ipv4-nordgw1
title = ipv4-nordgw1
probe = FPing
host = 10.207.11.11
#alerts = someloss



++ ipv6-nordgw1
menu = ipv6-nordgw1
title = ipv6-nordgw1
probe = FPing6
host = fec0::a:cf:b:b
#alerts = someloss



++ ipv4-nordgw10
menu = ipv4-nordgw10
title = ipv4-nordgw10
probe = FPing
host = 10.207.11.20
#alerts = someloss



++ ipv6-nordgw10
menu = ipv6-nordgw10
title = ipv6-nordgw10
probe = FPing6
host = fec0::a:cf:b:14
#alerts = someloss



++ ipv4-nordgw11
menu = ipv4-nordgw11
title = ipv4-nordgw11
probe = FPing
host = 10.207.11.21
#alerts = someloss
```
Nachher:
```
+ nord
menu = nord
title = nord



++ ipv4-nordgw0
menu = ipv4-nordgw0
title = ipv4-nordgw0
probe = FPing
host = 10.207.11.10
#alerts = someloss



++ ipv6-nordgw0
menu = ipv6-nordgw0
title = ipv6-nordgw0
probe = FPing6
host = fec0::a:cf:b:a
#alerts = someloss



++ ipv4-nordgw1
menu = ipv4-nordgw1
title = ipv4-nordgw1
probe = FPing
host = 10.207.11.11
#alerts = someloss



++ ipv6-nordgw1
menu = ipv6-nordgw1
title = ipv6-nordgw1
probe = FPing6
host = fec0::a:cf:b:b
#alerts = someloss



++ ipv4-nordgw2
menu = ipv4-nordgw2
title = ipv4-nordgw2
probe = FPing
host = 10.207.11.12
#alerts = someloss
```