### PR TITLE
adding private-domain to unbound config

### DIFF
--- a/mkdns
+++ b/mkdns
@@ -72,6 +72,7 @@ class UnboundForwardFormatter(object):
             self.buffer.append('\n\t# %s' % community)
             for zone in zone_type['forward'].keys():
                 self.buffer.append('\tdomain-insecure: "%s"' % zone)
+                self.buffer.append('\tprivate-domain: "%s"' % zone)
             for zone in zone_type['reverse'].keys():
                 self.buffer.append('\tdomain-insecure: "%s"' % zone)
                 self.buffer.append('\tlocal-zone: "%s" nodefault' % zone)


### PR DESCRIPTION
When having unbound configured to also be a resolver for public internet, it's common to use rebind protection (keyword private-address). But using rebind protection upstream also breaks resolution of icvpn hostnames with IPs in private address range.
Adding private-domain reallows those domains to contain private addresses.